### PR TITLE
test: :white_check_mark: add: 05/03/25 - implementando testes unitári…

### DIFF
--- a/public/Testes.md
+++ b/public/Testes.md
@@ -16,9 +16,10 @@ OK - FilterSelect {
 }
 
 CountryCard {
-  Testar Renderização do card
-  Testar renderização dos elementos (img, title, descriptions)
-  Testar se é clicável
+  OK - Testar renderização do Skeleton
+  OK - Testar Renderização dos 8 cards e seus elementos (img, title, paragrafos)
+  OK - Testar se ao clicar leva para o endpoint `/overview`
+  Testar se tiver uma lista de países no input ou select, é renderizado tudo.  -> Integração
 }
 
 CountryOverview {

--- a/src/__mocks__/countriesMock.ts
+++ b/src/__mocks__/countriesMock.ts
@@ -1,0 +1,347 @@
+import { ICountry } from "src/common/interfaces/ICountry";
+
+export const mockCountries: ICountry[] = [
+  {
+    "flags": {
+      "png": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Flag_of_the_Taliban.svg/320px-Flag_of_the_Taliban.svg.png",
+      "svg": "https://upload.wikimedia.org/wikipedia/commons/5/5c/Flag_of_the_Taliban.svg",
+      "alt": "The flag of the Islamic Emirate of Afghanistan has a white field with Arabic inscriptions — the Shahada — in black across its center."
+    },
+    "name": {
+      "common": "Afghanistan",
+      "official": "Islamic Republic of Afghanistan",
+      "nativeName": {
+        "prs": {
+          "official": "جمهوری اسلامی افغانستان",
+          "common": "افغانستان"
+        },
+        "pus": {
+          "official": "د افغانستان اسلامي جمهوریت",
+          "common": "افغانستان"
+        },
+        "tuk": {
+          "official": "Owganystan Yslam Respublikasy",
+          "common": "Owganystan"
+        }
+      }
+    },
+    "tld": [
+      ".af"
+    ],
+    "currencies": {
+      "AFN": {
+        "name": "Afghan afghani",
+        "symbol": "؋"
+      }
+    },
+    "capital": [
+      "Kabul"
+    ],
+    "region": "Asia",
+    "subregion": "Southern Asia",
+    "languages": {
+      "prs": "Dari",
+      "pus": "Pashto",
+      "tuk": "Turkmen"
+    },
+    "borders": [
+      "IRN",
+      "PAK",
+      "TKM",
+      "UZB",
+      "TJK",
+      "CHN"
+    ],
+    "population": 40218234
+  },
+  {
+    "flags": {
+      "png": "https://flagcdn.com/w320/dz.png",
+      "svg": "https://flagcdn.com/dz.svg",
+      "alt": "The flag of Algeria features two equal vertical bands of green and white. A five-pointed red star within a fly-side facing red crescent is centered over the two-color boundary."
+    },
+    "name": {
+      "common": "Algeria",
+      "official": "People's Democratic Republic of Algeria",
+      "nativeName": {
+        "ara": {
+          "official": "الجمهورية الديمقراطية الشعبية الجزائرية",
+          "common": "الجزائر"
+        }
+      }
+    },
+    "tld": [
+      ".dz",
+      "الجزائر."
+    ],
+    "currencies": {
+      "DZD": {
+        "name": "Algerian dinar",
+        "symbol": "د.ج"
+      }
+    },
+    "capital": [
+      "Algiers"
+    ],
+    "region": "Africa",
+    "subregion": "Northern Africa",
+    "languages": {
+      "ara": "Arabic"
+    },
+    "borders": [
+      "TUN",
+      "LBY",
+      "NER",
+      "ESH",
+      "MRT",
+      "MLI",
+      "MAR"
+    ],
+    "population": 44700000
+  },
+  {
+    "flags": {
+      "png": "https://flagcdn.com/w320/de.png",
+      "svg": "https://flagcdn.com/de.svg",
+      "alt": "The flag of Germany is composed of three equal horizontal bands of black, red and gold."
+    },
+    "name": {
+      "common": "Germany",
+      "official": "Federal Republic of Germany",
+      "nativeName": {
+        "deu": {
+          "official": "Bundesrepublik Deutschland",
+          "common": "Deutschland"
+        }
+      }
+    },
+    "tld": [
+      ".de"
+    ],
+    "currencies": {
+      "EUR": {
+        "name": "Euro",
+        "symbol": "€"
+      }
+    },
+    "capital": [
+      "Berlin"
+    ],
+    "region": "Europe",
+    "subregion": "Western Europe",
+    "languages": {
+      "deu": "German"
+    },
+    "borders": [
+      "AUT",
+      "BEL",
+      "CZE",
+      "DNK",
+      "FRA",
+      "LUX",
+      "NLD",
+      "POL",
+      "CHE"
+    ],
+    "population": 83240525
+  },
+  {
+    "flags": {
+      "png": "https://flagcdn.com/w320/is.png",
+      "svg": "https://flagcdn.com/is.svg",
+      "alt": "The flag of Iceland has a blue field with a large white-edged red cross that extends to the edges of the field. The vertical part of this cross is offset towards the hoist side."
+    },
+    "name": {
+      "common": "Iceland",
+      "official": "Iceland",
+      "nativeName": {
+        "isl": {
+          "official": "Ísland",
+          "common": "Ísland"
+        }
+      }
+    },
+    "tld": [
+      ".is"
+    ],
+    "currencies": {
+      "ISK": {
+        "name": "Icelandic króna",
+        "symbol": "kr"
+      }
+    },
+    "capital": [
+      "Reykjavik"
+    ],
+    "region": "Europe",
+    "subregion": "Northern Europe",
+    "languages": {
+      "isl": "Icelandic"
+    },
+    "borders": [],
+    "population": 366425
+  },
+  {
+    "flags": {
+      "png": "https://flagcdn.com/w320/ax.png",
+      "svg": "https://flagcdn.com/ax.svg",
+      "alt": ""
+    },
+    "name": {
+      "common": "Åland Islands",
+      "official": "Åland Islands",
+      "nativeName": {
+        "swe": {
+          "official": "Landskapet Åland",
+          "common": "Åland"
+        }
+      }
+    },
+    "tld": [
+      ".ax"
+    ],
+    "currencies": {
+      "EUR": {
+        "name": "Euro",
+        "symbol": "€"
+      }
+    },
+    "capital": [
+      "Mariehamn"
+    ],
+    "region": "Europe",
+    "subregion": "Northern Europe",
+    "languages": {
+      "swe": "Swedish"
+    },
+    "borders": [],
+    "population": 29458
+  },
+  {
+    "flags": {
+      "png": "https://flagcdn.com/w320/us.png",
+      "svg": "https://flagcdn.com/us.svg",
+      "alt": "The flag of the United States of America is composed of thirteen equal horizontal bands of red alternating with white. A blue rectangle, bearing fifty small five-pointed white stars arranged in nine rows where rows of six stars alternate with rows of five stars, is superimposed in the canton."
+    },
+    "name": {
+      "common": "United States",
+      "official": "United States of America",
+      "nativeName": {
+        "eng": {
+          "official": "United States of America",
+          "common": "United States"
+        }
+      }
+    },
+    "tld": [
+      ".us"
+    ],
+    "currencies": {
+      "USD": {
+        "name": "United States dollar",
+        "symbol": "$"
+      }
+    },
+    "capital": [
+      "Washington, D.C."
+    ],
+    "region": "Americas",
+    "subregion": "North America",
+    "languages": {
+      "eng": "English"
+    },
+    "borders": [
+      "CAN",
+      "MEX"
+    ],
+    "population": 329484123
+  },
+  {
+    "flags": {
+      "png": "https://flagcdn.com/w320/al.png",
+      "svg": "https://flagcdn.com/al.svg",
+      "alt": "The flag of Albania features a silhouetted double-headed black eagle at the center of a red field."
+    },
+    "name": {
+      "common": "Albania",
+      "official": "Republic of Albania",
+      "nativeName": {
+        "sqi": {
+          "official": "Republika e Shqipërisë",
+          "common": "Shqipëria"
+        }
+      }
+    },
+    "tld": [
+      ".al"
+    ],
+    "currencies": {
+      "ALL": {
+        "name": "Albanian lek",
+        "symbol": "L"
+      }
+    },
+    "capital": [
+      "Tirana"
+    ],
+    "region": "Europe",
+    "subregion": "Southeast Europe",
+    "languages": {
+      "sqi": "Albanian"
+    },
+    "borders": [
+      "MNE",
+      "GRC",
+      "MKD",
+      "UNK"
+    ],
+    "population": 2837743
+  },
+  {
+    "flags": {
+      "png": "https://flagcdn.com/w320/br.png",
+      "svg": "https://flagcdn.com/br.svg",
+      "alt": "The flag of Brazil has a green field with a large yellow rhombus in the center. Within the rhombus is a dark blue globe with twenty-seven small five-pointed white stars depicting a starry sky and a thin white convex horizontal band inscribed with the national motto 'Ordem e Progresso' across its center."
+    },
+    "name": {
+      "common": "Brazil",
+      "official": "Federative Republic of Brazil",
+      "nativeName": {
+        "por": {
+          "official": "República Federativa do Brasil",
+          "common": "Brasil"
+        }
+      }
+    },
+    "tld": [
+      ".br"
+    ],
+    "currencies": {
+      "BRL": {
+        "name": "Brazilian real",
+        "symbol": "R$"
+      }
+    },
+    "capital": [
+      "Brasília"
+    ],
+    "region": "Americas",
+    "subregion": "South America",
+    "languages": {
+      "por": "Portuguese"
+    },
+    "borders": [
+      "ARG",
+      "BOL",
+      "COL",
+      "GUF",
+      "GUY",
+      "PRY",
+      "PER",
+      "SUR",
+      "URY",
+      "VEN"
+    ],
+    "population": 212559409
+  }
+];

--- a/src/common/interfaces/ICountry.ts
+++ b/src/common/interfaces/ICountry.ts
@@ -35,7 +35,6 @@ export interface ICountry {
   capital: string[];
   tld: string[];
   currencies: ICurrencies;
-  languages: string[];
+  languages: { [key: string]: string };
   borders: string[];
-  error: boolean;
 }

--- a/src/common/states/hook/useCountryNamesFromCodes.tsx
+++ b/src/common/states/hook/useCountryNamesFromCodes.tsx
@@ -3,8 +3,6 @@ import { getApi } from 'src/utils/http';
 import { ICountry } from '../../interfaces/ICountry';
 
 export function useCountryNamesFromCodes(country: ICountry) {
-  console.log('country: ', country);
-
   const bordersCountries = country?.borders?.join(',') || '';
 
   const { data: borderCountriesData = [], isLoading, isError } = useQuery({

--- a/src/components/CountryCard/SkeletonCountryCard.tsx
+++ b/src/components/CountryCard/SkeletonCountryCard.tsx
@@ -9,7 +9,7 @@ export default function SkeletonCountryCard() {
   return (
     <CountryCardsContainer>
       {Array(8).fill(null).map((_, index) => (
-        <Link to="/" key={index}>
+        <Link to="/" key={index} data-testid="skeleton-country-card">
           <article>
             <Skeleton height={160} baseColor={theme.skeletonBaseColorImg}   />
             <CountryCardDetails>

--- a/src/components/CountryCard/countryCard.spec.tsx
+++ b/src/components/CountryCard/countryCard.spec.tsx
@@ -1,0 +1,87 @@
+import { RecoilRoot } from "recoil";
+import customRender from "src/tests/utils/customRender";
+import { vi } from "vitest";
+import CountryCard from ".";
+import { countryFilterState } from "src/common/states/atom";
+import { fireEvent, screen } from "@testing-library/react";
+import { ThemeWrapper } from "src/tests/utils/ThemeWrapper";
+import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { useFilteredCountries } from "src/common/states/hook/useFilteredCountries";
+import { mockCountries } from "src/__mocks__/countriesMock";
+import CountryOverview from "src/pages/CountryOverview";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ICountry } from "src/common/interfaces/ICountry";
+
+vi.mock("src/common/states/hook/useFilteredCountries");
+
+const renderWithRecoil = (filteredCountries: ICountry[] = [], isLoading = false, isError = false) => {
+  vi.mocked(useFilteredCountries).mockReturnValue({
+    filteredCountries,
+    isLoading,
+    isError,
+  });
+
+  const onChangeMock = vi.fn();
+  const queryClient = new QueryClient();
+
+  const { user } = customRender(
+    <RecoilRoot>
+      <QueryClientProvider client={queryClient}>
+        <ThemeWrapper state={countryFilterState} onChangeMock={onChangeMock}>
+          <Router>
+            <Routes>
+              <Route path="/" element={<CountryCard />} />
+              <Route path="/overview" element={<CountryOverview />} />
+            </Routes>
+          </Router>
+        </ThemeWrapper>
+      </QueryClientProvider>
+    </RecoilRoot>
+  );
+
+  return { user, onChangeMock };
+};
+
+describe('<CountryCard />', () => {
+  const initialCountries = [
+    'Germany', 'United States', 'Brazil', 'Iceland', 'Afghanistan',
+    'Åland Islands', 'Albania', 'Algeria'
+  ];
+
+  const countryDetails = ['Population:', 'Region:', 'Capital:'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Should render the skeleton initially', () => {
+    renderWithRecoil([], true);
+
+    expect(screen.getAllByTestId("skeleton-country-card")).toHaveLength(8);
+  });
+
+  
+  it('Should render letters from the eight initial countries', async () => {    
+    renderWithRecoil(mockCountries);
+
+    initialCountries.forEach(country => {
+      expect(screen.getByRole("heading", { level: 2, name: country })).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByRole('img')).toHaveLength(8);
+
+    countryDetails.forEach(countryDetail => {
+      expect(screen.getAllByText(countryDetail)).toHaveLength(8);
+    });
+  });
+
+  it('Should redirect to `/overview` endpoint when clicking on the country.', async () => {
+    renderWithRecoil(mockCountries);
+
+    const countryCard = screen.getByRole('heading', { level: 2, name: 'Brazil' });
+    await fireEvent.click(countryCard);
+
+    expect(window.location.pathname).toBe("/overview");
+    expect(screen.getByRole("link", { name: /back/i })).toContainElement(screen.getByTestId("arrow-icon"));
+  });
+});

--- a/src/components/CountryCard/index.tsx
+++ b/src/components/CountryCard/index.tsx
@@ -134,7 +134,7 @@ export default function CountryCard() {
   const setSelectedCountry = useSetRecoilState(selectedCountryState);
   const countryFilter = useRecoilValue(countryFilterState);
   const { filteredCountries, isLoading, isError } = useFilteredCountries(countryFilter?.input, countryFilter?.select);
-  const {limit, setLimit} = useCardLimitByScreenSize();
+  const { limit, setLimit } = useCardLimitByScreenSize();
   const animation = animatedTransition();
 
   if (isLoading) {
@@ -152,16 +152,16 @@ export default function CountryCard() {
   return (
     <CardsContainerWrapper>
       <CountryCardsContainer>
-        { filteredCountries.length > 0 ?
+        {filteredCountries.length > 0 ?
           filteredCountries.slice(0, limit.sliceLimit).map((country) => (
-            <Link 
-              to="/overview" 
+            <Link
+              to="/overview"
               key={country.name.common}
               onClick={() => setSelectedCountry(country)}
-            >        
+            >
               <motion.article {...animation}>
                 <img src={country.flags.png} alt={`Bandeira - ${country.name.common}`} />
-                
+
                 <CountryCardDetails>
                   <h2>{country.name.common}</h2>
                   <div>
@@ -177,13 +177,13 @@ export default function CountryCard() {
         }
       </CountryCardsContainer>
 
-      {filteredCountries.length > limit.cardsLimit ? 
+      {filteredCountries.length > limit.cardsLimit ?
         (
           <StylizedButton
             onClick={() =>
               filteredCountries.length > limit.sliceLimit
-                ? setLimit({...limit, sliceLimit: limit.sliceLimit + limit.cardsLimit})
-                : setLimit({...limit, sliceLimit: limit.cardsLimit})
+                ? setLimit({ ...limit, sliceLimit: limit.sliceLimit + limit.cardsLimit })
+                : setLimit({ ...limit, sliceLimit: limit.cardsLimit })
             }
           >
             {filteredCountries.length > limit.sliceLimit ? 'Load More' : 'Show Less'}

--- a/src/pages/CountryOverview.tsx
+++ b/src/pages/CountryOverview.tsx
@@ -25,11 +25,10 @@ export const StylizedLink = styled(Link)`
 `;
 
 export default function CountryOverview() {
-
   return (
     <div>
       <StylizedLink to="/">
-        <ArrowIcon />
+        <ArrowIcon data-testid="arrow-icon" />
         Back
       </StylizedLink>
 


### PR DESCRIPTION
- Implementado teste para verificar a renderização do componente Skeleton.
- Adicionado teste para garantir que os 8 cards sejam renderizados corretamente com seus elementos (imagem, título e parágrafos).
- Criado teste para verificar se a navegação para o endpoint /overview ocorre corretamente ao clicar em um card.